### PR TITLE
feat: Update README and add detailed documentation for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ The `symlinks` script is used to install or uninstall dotfile packages.
 ```
 
 ---
-This `README.md` provides a brief overview. For comprehensive information, please visit the [documentation site](https://fralomb.github.io/dotfiles/).
+This `README.md` provides a brief overview. For comprehensive information, please visit the [documentation site](https://fralomb.github.io/dotfiles/) which uses the Jekyll Hacker theme.

--- a/README.md
+++ b/README.md
@@ -1,103 +1,48 @@
-# dotfiles
-Collection of all my configuration files
+# Dotfiles Management
 
-## Installation
-The `symlinks` script manages all the dotfiles contained in this repo by means of the **stow** command.
+**For detailed documentation, please visit our [GitHub Pages site](https://YOUR_GITHUB_USERNAME.github.io/YOUR_REPOSITORY_NAME/).**
+Please replace `YOUR_GITHUB_USERNAME` and `YOUR_REPOSITORY_NAME` with your actual GitHub username and repository name.
 
-It will create / remove a symlink for each specified **package**, a collection of files and directories that you wish to administer as a unit and that needs to be installed in a particular directory structure (starting from a **target folder**).
+This repository contains a collection of personal and work dotfiles, configurations for npm packages, Brew-installed tools, and a script for managing symlinks.
 
-One or more packages will __appear__ to be installed in a **target directory**, the root tree in which the symlinks will be created.
+## Core Components
 
-It is possible to ignore some files or directories passing it as a parameter through the `--ignore` option.
-Also, inside a package directory it can be defined a `.target` file, containing a path to a target file that differs from the current folder structure.
+*   **Dotfiles:** Personal (`main/`) and work-related (`other/`) configurations for various tools including Zsh, Neovim, Git, Alacritty, Tmux, and more.
+*   **`symlinks` Script:** A utility script leveraging `stow` to manage the symlinking of these dotfiles into their correct locations.
+*   **`Brewfile`:** Manages macOS application and tool installations via Homebrew.
+*   **`package.json`:** Lists Node.js dependencies, primarily for Neovim LSP support and other development utilities.
+*   **Themes:** Includes color schemes like Rose Pine for iTerm2.
 
-Usage:
+## Quick Start with `symlinks` Script
+
+The `symlinks` script is used to install or uninstall dotfile packages.
+
+### Basic Usage:
+```bash
+# Install a personal Zsh configuration
+./symlinks -i main/zsh
+
+# Uninstall a work-specific Git configuration
+./symlinks -u other/git
+
+# Install a package to a custom target directory
+./symlinks -i -t ~/.config/other_configs other/specific_tool
 ```
-  ./symlinks [--install | -i] [--uninstall | -u] [--recursive | -r] [--target | -t] <TARGET_VALUE> FOLDER
-```
-Explanation:
-* [--install | -i]: will create symlinks to TARGET folder
-* [--uninstall | -u]: will remove previously created symlinks from TARGET folder (if any)
-* [--target | -t] TARGET_VALUE: the target folder (default: $HOME)
-* [--recursive | -r]: will iterate through dirs inside FOLDER (the stow package) and stow all the content
-* [--help | -h]: show the helper menu
-* FOLDER: the source folder to use to create/delete the symlink
+For more detailed instructions on the `symlinks` script, dotfile configurations, Homebrew packages, NPM dependencies, and Neovim setup, please refer to the [full documentation site](https://YOUR_GITHUB_USERNAME.github.io/YOUR_REPOSITORY_NAME/).
+Please replace `YOUR_GITHUB_USERNAME` and `YOUR_REPOSITORY_NAME` with your actual GitHub username and repository name.
 
-### Neovim
-#### build prerequisites
-[neovim prerequisites](https://github.com/neovim/neovim/wiki/Building-Neovim#build-prerequisites)
+## Repository Structure Overview
 
-#### remove everything about nvim
-- rm -rf ~/.environment/.neovim
-- rm -rf ~/.config/nvim
-- rm -rf ~/.local/share/nvim
+*   `docs/`: Contains all detailed documentation for the GitHub Pages site.
+*   `main/`: Personal dotfile configurations.
+    *   `ai/`, `alacritty/`, `aws/`, `bat/`, `docker/`, `gh/`, `git/`, `neovim/`, `ssh/`, `terraform/`, `tmux/`, `zsh/`
+*   `other/`: Work-specific dotfile configurations.
+    *   `gh/`, `git/`, `saml/`, `zsh/`
+*   `theme/`: Terminal themes.
+*   `Brewfile`: Homebrew package list.
+*   `package.json`: NPM dependency list.
+*   `symlinks`: The symlink management script.
 
-#### plugin dependencies
-`nerd-fonts`: install patched fonts from [nerd-fonts](https://github.com/ryanoasis/nerd-fonts)
-on macos:
-```
-brew tap homebrew/cask-fonts
-brew install --cask font-hack-nerd-font
-```
-> [!warning]
-> make sure the patched font is used by the terminal
-
-#### neovim plugins
-- `mason` needs:
-  - `wget`
-  - `curl https://sh.rustup.rs -sSf | sh` installs `cargo` and `rust`
-- `vim-cmp`: Follow configuration here: [doc](https://github.com/hrsh7th/nvim-cmp)
-- `Telescope`: as a dependencies install `ripgrep`
-- `Harpoon`: [doc](https://github.com/ThePrimeagen/harpoon)
-
-#### neovim LSPs
-- c compiler: `sudo apt-get install build-essential`
-- bashls depends on `brew install shellcheck` for linting
-- bash
-  - install npm before `sudo apt-get install nodejs`
-  - `npm i -g bash-language-server`
-- python
-  - [doc](https://github.com/palantir/python-language-server)
-- Java
-  - `https://github.com/mfussenegger/nvim-jdtls`
-  - `https://github.com/eclipse/eclipse.jdt.ls#installation`
-  - `https://github.com/mfussenegger/nvim-dap`
-  - `https://github.com/microsoft/vscode-java-test`
-  - `apt-get install -y maven`
-  - `apt-get install -y openjdk-8-jdk`
-- Python
-  - flake8 for diagnostic `pip install flake8`
-  - autopep8 for formatting `pip install autopep8`
-  - install `pip3 install pynvim` that implements support for python plugins in Nvim
-- HURL
-  - test curl request easily: https://hurl.dev
-- gopls
- - installation through `go install golang.org/x/tools/gopls@latest`
-- HTML/CSS
-  - Emmet toolkit for html, css and javascript development
-  - `https://github.com/mattn/emmet-vim`
-  - `https://raw.githubusercontent.com/mattn/emmet-vim/master/TUTORIAL`
-- terraform:
-  - `brew install hashicorp/tap/terraform-ls`
-  - [doc](https://github.com/hashicorp/terraform-ls)
-- packer: `brew tap hashicorp/tap && brew install hashicorp/tap/packer`
-- htmx: `cargo install htmx-lsp` - documentation [here](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#htmx)
-- tailwindcss: `npm install -g @tailwindcss/language-server` - documentation [here](https://github.com/tailwindlabs/tailwindcss-intellisense/tree/master/packages/tailwindcss-language-server) and [here](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#tailwindcss)
-- angular: lsp can be installed via npm `npm install -g @angular/language-server`, angular cli can be installed running `npm install -g @angular/cli` - documentation [here](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#angularls)
-
-### Brewfile
-Contains all the macOs packages installed via homebrew. Documentation [here](https://github.com/Homebrew/homebrew-bundle).
-- To install all dependencies run `brew bundle install --verbose --file Brewfile` command.
-- To get all the installed packages run `brew bundle dump --file=Brewfile` command.
-- To uninstall all formulae not listed in the Brewfile run `brew bundle cleanup --force` command.
-- To check if there is anything to install or upgrade in the Brewfile run `brew bundle check` command.
-- To output the list of all entries in the Brewfile run `brew bundle list --all` command.
-
-### Other dependencies
-- ZSH: [doc](https://wiki.archlinux.org/title/zsh#History_search)
-- fzf: [doc](https://github.com/unixorn/fzf-zsh-plugin)
-- watch: `brew install watch`
-- oathtool: `brew install oath-toolkit`
-
-### Github Copilot
-Documentation [here](https://github.com/github/copilot.vim?tab=readme-ov-file)
+---
+This `README.md` provides a brief overview. For comprehensive information, please visit the [documentation site](https://YOUR_GITHUB_USERNAME.github.io/YOUR_REPOSITORY_NAME/).
+Please replace `YOUR_GITHUB_USERNAME` and `YOUR_REPOSITORY_NAME` with your actual GitHub username and repository name.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 # Dotfiles Management
 
-**For detailed documentation, please visit our [GitHub Pages site](https://YOUR_GITHUB_USERNAME.github.io/YOUR_REPOSITORY_NAME/).**
-Please replace `YOUR_GITHUB_USERNAME` and `YOUR_REPOSITORY_NAME` with your actual GitHub username and repository name.
-
 This repository contains a collection of personal and work dotfiles, configurations for npm packages, Brew-installed tools, and a script for managing symlinks.
 
 ## Core Components
 
-*   **Dotfiles:** Personal (`main/`) and work-related (`other/`) configurations for various tools including Zsh, Neovim, Git, Alacritty, Tmux, and more.
+*   **Dotfiles:** Configurations for various tools including Zsh, Neovim, Git, Alacritty, Tmux, and more.
 *   **`symlinks` Script:** A utility script leveraging `stow` to manage the symlinking of these dotfiles into their correct locations.
 *   **`Brewfile`:** Manages macOS application and tool installations via Homebrew.
 *   **`package.json`:** Lists Node.js dependencies, primarily for Neovim LSP support and other development utilities.
@@ -28,21 +25,6 @@ The `symlinks` script is used to install or uninstall dotfile packages.
 # Install a package to a custom target directory
 ./symlinks -i -t ~/.config/other_configs other/specific_tool
 ```
-For more detailed instructions on the `symlinks` script, dotfile configurations, Homebrew packages, NPM dependencies, and Neovim setup, please refer to the [full documentation site](https://YOUR_GITHUB_USERNAME.github.io/YOUR_REPOSITORY_NAME/).
-Please replace `YOUR_GITHUB_USERNAME` and `YOUR_REPOSITORY_NAME` with your actual GitHub username and repository name.
-
-## Repository Structure Overview
-
-*   `docs/`: Contains all detailed documentation for the GitHub Pages site.
-*   `main/`: Personal dotfile configurations.
-    *   `ai/`, `alacritty/`, `aws/`, `bat/`, `docker/`, `gh/`, `git/`, `neovim/`, `ssh/`, `terraform/`, `tmux/`, `zsh/`
-*   `other/`: Work-specific dotfile configurations.
-    *   `gh/`, `git/`, `saml/`, `zsh/`
-*   `theme/`: Terminal themes.
-*   `Brewfile`: Homebrew package list.
-*   `package.json`: NPM dependency list.
-*   `symlinks`: The symlink management script.
 
 ---
-This `README.md` provides a brief overview. For comprehensive information, please visit the [documentation site](https://YOUR_GITHUB_USERNAME.github.io/YOUR_REPOSITORY_NAME/).
-Please replace `YOUR_GITHUB_USERNAME` and `YOUR_REPOSITORY_NAME` with your actual GitHub username and repository name.
+This `README.md` provides a brief overview. For comprehensive information, please visit the [documentation site](https://fralomb.github.io/dotfiles/).

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,8 @@
+theme: jekyll-theme-hacker
+title: Dotfiles Documentation
+description: Comprehensive documentation for personal dotfiles and configurations
+show_downloads: false
+github:
+  repository_url: https://github.com/fralomb/dotfiles
+  owner_name: fralomb
+  is_project_page: true

--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,0 +1,3 @@
+<!-- Custom head content -->
+<link rel="icon" type="image/x-icon" href="{{ '/assets/images/favicon.ico' | relative_url }}">
+<!-- End custom head content -->

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    {% include head-custom.html %}
+    {% seo %}
+  </head>
+
+  <body>
+    <header>
+      <div class="container">
+        <a id="a-title" href="{{ '/' | relative_url }}">
+          <h1>{{ site.title | default: site.github.repository_name }}</h1>
+        </a>
+        <h2>{{ site.description | default: site.github.project_tagline }}</h2>
+
+        <section id="downloads">
+          <a href="{{ site.github.repository_url }}" class="btn btn-github"><span class="icon"></span>View on GitHub</a>
+        </section>
+      </div>
+    </header>
+
+    <div class="container">
+      <section id="main_content">
+        {{ content }}
+      </section>
+    </div>
+
+    <div class="container">
+      <section id="navigation">
+        <h2>Navigation</h2>
+        <ul>
+          <li><a href="{{ '/' | relative_url }}">Home</a></li>
+          <li><a href="{{ '/dotfiles.html' | relative_url }}">Dotfiles</a></li>
+          <li><a href="{{ '/symlink-script.html' | relative_url }}">Symlink Script</a></li>
+          <li><a href="{{ '/brew.html' | relative_url }}">Homebrew Packages</a></li>
+          <li><a href="{{ '/npm.html' | relative_url }}">NPM Packages</a></li>
+          <li><a href="{{ '/neovim.html' | relative_url }}">Neovim Configuration</a></li>
+        </ul>
+      </section>
+    </div>
+
+    <footer>
+      <div class="container">
+        <p>Managed with <span class="heart">♥</span> by <a href="https://github.com/fralomb">fralomb</a></p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1,0 +1,84 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+// Add custom styles here
+body {
+  background-color: #151515;
+  color: #eaeaea;
+}
+
+header {
+  border-bottom: 1px dashed #b5e853;
+  padding-bottom: 20px;
+}
+
+.container {
+  max-width: 90%;
+  margin: 0 auto;
+}
+
+a {
+  color: #63c0f5;
+  text-shadow: 0 0 5px rgba(104, 182, 255, 0.5);
+  &:hover {
+    color: #b5e853;
+  }
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #b5e853;
+}
+
+#navigation {
+  margin-top: 40px;
+  border-top: 1px dashed #b5e853;
+  padding-top: 20px;
+}
+
+#navigation ul {
+  list-style-type: none;
+  padding: 0;
+}
+
+#navigation li {
+  display: inline-block;
+  margin-right: 20px;
+}
+
+footer {
+  margin-top: 40px;
+  padding: 20px 0;
+  border-top: 1px dashed #b5e853;
+  text-align: center;
+}
+
+.heart {
+  color: #b5e853;
+}
+
+pre {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  padding: 10px;
+  font-size: 14px;
+  color: #b5e853;
+  border-radius: 2px;
+  word-wrap: normal;
+  overflow: auto;
+  overflow-y: hidden;
+}
+
+code.highlighter-rouge {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  padding: 0 3px;
+  margin: 0 2px;
+  color: #aa759f;
+  border-radius: 2px;
+}
+
+.highlight {
+  background: #222;
+}

--- a/docs/brew.md
+++ b/docs/brew.md
@@ -1,0 +1,131 @@
+# Homebrew Packages and Setup
+
+This document details the macOS packages managed via the `Brewfile` in this repository. Homebrew is a package manager for macOS that simplifies the installation and management of software. Using a `Brewfile` allows for easy setup and replication of the development environment across multiple Macs.
+
+## Managing Brewfile
+
+The `Brewfile` is located at the root of the repository. Here are the common commands for managing packages with it:
+
+*   **Install all dependencies:**
+    ```bash
+    brew bundle install --verbose --file Brewfile
+    ```
+    This command reads the `Brewfile` and installs all listed formulae (command-line tools) and casks (GUI applications).
+
+*   **Update Brewfile with currently installed packages:**
+    ```bash
+    brew bundle dump --file=Brewfile --force
+    ```
+    This command will overwrite the existing `Brewfile` with a list of all currently installed Homebrew packages. Use `--force` to overwrite.
+
+*   **Uninstall formulae not listed in the Brewfile:**
+    ```bash
+    brew bundle cleanup --force
+    ```
+    This command will remove any installed packages that are not present in the `Brewfile`. Use with caution.
+
+*   **Check for missing or outdated packages:**
+    ```bash
+    brew bundle check
+    ```
+    This command checks if all packages listed in the `Brewfile` are installed and up-to-date.
+
+*   **List all entries in the Brewfile:**
+    ```bash
+    brew bundle list --all
+    ```
+    This command outputs a list of all packages specified in the `Brewfile`.
+
+## Installed Packages
+
+The following packages are managed by the `Brewfile`, grouped by their purpose:
+
+### Terminal Icons & Fonts
+These packages provide fonts that include a wide range of icons, often used in terminal applications and text editors like Neovim.
+*   **`homebrew/cask-fonts` (Tap):** A repository of fonts for Homebrew.
+*   **`font-hack-nerd-font` (Cask):** A patched version of the Hack font with Nerd Fonts glyphs, providing numerous icons.
+
+### Development Tools
+Core tools for software development.
+*   **`neovim`:** A highly extensible, Vim-based text editor, optimized for speed and flexibility. (See [Neovim Configuration](./neovim.md))
+*   **`stow`:** GNU Stow, a symlink farm manager used by the `symlinks` script to manage dotfiles.
+*   **`tmux`:** A terminal multiplexer, allowing multiple terminal sessions to be accessed from a single window.
+*   **`watch`:** Executes a program periodically, showing its output and/or highlighting changes.
+*   **`wget`:** A free utility for non-interactive download of files from the web.
+*   **`nmap`:** A powerful network exploration tool and security/port scanner.
+*   **`zsh`:** A powerful shell with more features than bash. (See [Zsh Configuration](./dotfiles.md#zsh-mainzsh))
+*   **`hurl`:** A command-line tool that runs HTTP requests defined in a simple plain text format.
+*   **`podman`:** A daemonless container engine for developing, managing, and running OCI Containers on your Linux System. (Alternative to Docker Desktop)
+*   **`python@3.11`:** Specific version of Python 3.11.
+*   **`python@3.10`:** Specific version of Python 3.10.
+*   **`virtualenv`:** A tool to create isolated Python environments.
+*   **`go`:** The Go programming language.
+*   **`node`:** Node.js, a JavaScript runtime built on Chrome's V8 JavaScript engine.
+*   **`testssl`:** A command-line tool to check a server's TLS/SSL configuration.
+
+### AWS (Amazon Web Services)
+Tools for interacting with AWS.
+*   **`session-manager-plugin` (Cask):** An AWS CLI plugin to start and end sessions that connect you to your instances.
+*   **`awscli`:** The official Amazon Web Services command-line interface.
+*   **`weaveworks/tap/eksctl` (Tap & Formula):** A simple CLI tool for creating and managing clusters on EKS (Amazon's managed Kubernetes service).
+
+### Pulumi
+Tools for the Pulumi infrastructure as code platform.
+*   **`pulumi/tap/pulumi` (Tap & Formula):** The Pulumi CLI, for creating, deploying, and managing cloud infrastructure.
+
+### HashiCorp
+Tools from HashiCorp for infrastructure automation.
+*   **`hashicorp/tap` (Tap):** HashiCorp's official Homebrew tap.
+*   **`hashicorp/tap/packer`:** Packer, a tool for creating identical machine images for multiple platforms from a single source configuration.
+*   **`hashicorp/tap/terraform`:** Terraform, an infrastructure as code tool for building, changing, and versioning infrastructure safely and efficiently.
+*   **`terraform-docs`:** A utility to generate documentation from Terraform modules in various output formats.
+
+### Search and File Management
+Utilities for efficient file searching, viewing, and manipulation.
+*   **`bat`:** A `cat(1)` clone with syntax highlighting and Git integration.
+*   **`fd`:** A simple, fast and user-friendly alternative to `find`.
+*   **`fzf`:** A command-line fuzzy finder.
+*   **`ripgrep`:** A line-oriented search tool that recursively searches the current directory for a regex pattern.
+*   **`jinja2-cli`:** A command-line interface for Jinja2, a templating engine for Python.
+*   **`jq`:** A lightweight and flexible command-line JSON processor.
+*   **`catimg`:** A tool to display images in the terminal.
+*   **`tree`:** Displays directory listings in a tree-like format.
+*   **`yq`:** A lightweight and portable command-line YAML, JSON, and XML processor.
+
+### Git
+Tools and utilities for enhancing the Git workflow.
+*   **`gh`:** GitHub's official command-line tool.
+*   **`git-filter-repo`:** A versatile tool for rewriting Git repository history.
+*   **`gitleaks`:** A SAST tool for detecting and preventing hardcoded secrets like passwords, API keys, and tokens in git repos.
+*   **`pre-commit`:** A framework for managing and maintaining multi-language pre-commit hooks.
+*   **`git-crypt`:** Enables transparent file encryption in git.
+
+### OTP (One-Time Passwords)
+Tools for generating one-time passwords.
+*   **`oath-toolkit`:** A toolkit for implementing OATH (Initiative for Open Authentication) standards, including HOTP and TOTP.
+
+### Kubernetes
+Tools for managing Kubernetes clusters and applications.
+*   **`kubernetes-cli` (kubectl):** The command-line tool for controlling Kubernetes clusters.
+*   **`kubectx` (includes `kubens`):** A utility to switch between Kubernetes contexts (clusters) and namespaces easily.
+*   **`helm`:** The package manager for Kubernetes, helping you define, install, and upgrade even the most complex Kubernetes applications.
+*   **`weaveworks/tap` (Tap):** Weaveworks' official Homebrew tap (also used for `eksctl`).
+
+### LSP (Language Server Protocol) & Linters/Formatters
+Tools that provide language intelligence, linting, and formatting, often used with Neovim.
+*   **`viu`:** A command-line image viewer for the terminal. (Can be used by Neovim plugins to display images).
+*   **`shellcheck`:** A static analysis tool for shell scripts (bash, sh, zsh).
+*   **`shfmt`:** A shell parser, formatter, and interpreter with bash support; includes `shfmt`.
+*   **`hashicorp/tap/terraform-ls`:** Language server for Terraform.
+*   **`tflint`:** A Pluggable Terraform Linter.
+*   **`efm-langserver`:** A general-purpose Language Server that uses external tools to provide LSP features.
+*   **`stylua`:** An opinionated Lua code formatter.
+
+### Applications (Casks)
+GUI applications installed via Homebrew Cask.
+*   **`alacritty` (args: `{ no_quarantine: true }`):** A fast, cross-platform, OpenGL terminal emulator. The `no_quarantine` argument bypasses macOS Gatekeeper quarantine for this app.
+*   **`obsidian`:** A powerful knowledge base that works on local Markdown files.
+*   **`drawio`:** A diagramming and whiteboarding application (desktop version of diagrams.net).
+
+---
+This list provides a snapshot of the tools used in this development environment. The `Brewfile` is the single source of truth for all Homebrew-managed packages.

--- a/docs/brew.md
+++ b/docs/brew.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # Homebrew Packages and Setup
 
 This document details the macOS packages managed via the `Brewfile` in this repository. Homebrew is a package manager for macOS that simplifies the installation and management of software. Using a `Brewfile` allows for easy setup and replication of the development environment across multiple Macs.

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # Dotfile Configurations
 
 This section provides a detailed look into the various dotfile configurations managed within this repository. These configurations are essential for personalizing the development environment, streamlining workflows, and ensuring consistency across different tools and systems.

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -2,15 +2,9 @@
 
 This section provides a detailed look into the various dotfile configurations managed within this repository. These configurations are essential for personalizing the development environment, streamlining workflows, and ensuring consistency across different tools and systems.
 
-The dotfiles are organized into two main categories:
-*   **Main (Personal) Configurations:** Located in the `main/` directory, these are general-purpose configurations for everyday use.
-*   **Other (Work) Configurations:** Located in the `other/` directory, these are tailored for specific work-related setups and tools.
-
 The `symlinks` script is used to manage these configurations by creating symbolic links from the repository to their appropriate locations in the user's home directory or other specified target directories.
 
-## Main (Personal) Configurations
-
-These configurations are found in the `main/` directory and represent the primary setup for various applications and utilities.
+## Configurations
 
 ### AI (`main/ai`)
 This directory contains configurations related to Artificial Intelligence tools.
@@ -81,35 +75,6 @@ Zsh (Z shell) is a powerful and highly customizable shell. This configuration en
     *   `main/zsh/.config/zsh/aliases/`: Directory likely containing files with alias definitions, possibly organized by topic.
     *   `main/zsh/.config/zsh/plugins/`: Could contain custom or manually installed plugins.
     *   `main/zsh/.config/zsh/themes/`: Contains themes, including the `powerlevel10k` configuration (`p10k.zsh`).
-
-## Other (Work) Configurations
-
-These configurations are found in the `other/` directory and are specifically tailored for a work environment. They often override or supplement the main personal configurations.
-
-### GitHub CLI (`other/gh`)
-Work-specific configurations for the GitHub CLI (`gh`).
-*   **Purpose:** This configuration likely sets up `gh` to interact with a work-related GitHub Enterprise instance or a different GitHub user account used for professional projects.
-*   **Key Files:**
-    *   `other/gh/hosts.yml.other`: This file would contain the connection and authentication details for the work GitHub instance. The `.other` suffix suggests it's intended to be symlinked or copied to the appropriate location (e.g., `~/.config/gh/hosts.yml`) when the work environment is active.
-    *   `other/gh/.target`: This file likely specifies that `hosts.yml.other` should be symlinked as `hosts.yml` in the `~/.config/gh/` directory.
-
-### Git (`other/git`)
-Work-specific Git configurations.
-*   **Purpose:** To manage a separate Git identity (user name, email) for work contributions and potentially different Git settings or aliases relevant to the work environment.
-*   **Key Files:**
-    *   `other/git/.gitconfig.other`: Contains work-specific Git settings, such as work email and name. This file is typically included in the main global `.gitconfig` using Git's `includeIf` directive, activated based on the repository path (e.g., when in a `~/work/` directory).
-
-### SAML (`other/saml`)
-Configuration for SAML (Security Assertion Markup Language) based authentication, often used for Single Sign-On (SSO) to various services.
-*   **Purpose:** This likely configures tools like `saml2aws` which allow authentication to AWS or other cloud providers using corporate SAML SSO credentials.
-*   **Key Files:**
-    *   `other/saml/.saml2aws`: The configuration file for `saml2aws`. It stores profiles for different SSO providers and AWS roles, allowing users to log in and retrieve temporary AWS credentials.
-
-### Zsh (`other/zsh`)
-Work-specific Zsh configurations.
-*   **Purpose:** To add aliases, functions, or environment variables specific to the work environment, such_as connecting to work servers, managing work-specific projects, or using internal tools.
-*   **Key Files:**
-    *   `other/zsh/.config/utilities/`: This directory likely contains shell scripts or utility functions that are primarily used in a work context. These might be sourced by a work-specific Zsh configuration file. The specific files (`aws`, `git`, `kubectl`, `terraform`) suggest utilities for interacting with these tools, possibly with pre-configured settings or wrappers for work projects.
 
 ---
 Properly managing these dotfiles ensures a tailored and efficient environment for both personal and professional tasks. Remember to use the `symlinks` script to install or update these configurations.

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -1,0 +1,115 @@
+# Dotfile Configurations
+
+This section provides a detailed look into the various dotfile configurations managed within this repository. These configurations are essential for personalizing the development environment, streamlining workflows, and ensuring consistency across different tools and systems.
+
+The dotfiles are organized into two main categories:
+*   **Main (Personal) Configurations:** Located in the `main/` directory, these are general-purpose configurations for everyday use.
+*   **Other (Work) Configurations:** Located in the `other/` directory, these are tailored for specific work-related setups and tools.
+
+The `symlinks` script is used to manage these configurations by creating symbolic links from the repository to their appropriate locations in the user's home directory or other specified target directories.
+
+## Main (Personal) Configurations
+
+These configurations are found in the `main/` directory and represent the primary setup for various applications and utilities.
+
+### AI (`main/ai`)
+This directory contains configurations related to Artificial Intelligence tools.
+*   **`main/ai/.config/codestral`**: Configuration for Codestral, an AI coding assistant. (Further details about specific files would go here if known).
+
+### Alacritty (`main/alacritty`)
+Alacritty is a fast, cross-platform, OpenGL terminal emulator. Its configuration allows for extensive customization of appearance, key bindings, and performance.
+*   **Key Files:**
+    *   `main/alacritty/.config/alacritty/alacritty.toml`: The main configuration file for Alacritty, defining settings like font, colors, opacity, key bindings, and shell.
+    *   `main/alacritty/.config/alacritty/themes/`: Contains various themes for Alacritty. The `catppuccin_mocha.toml` is likely one such theme.
+
+### AWS (`main/aws`)
+Configurations for interacting with Amazon Web Services (AWS).
+*   **Key Files:**
+    *   `main/aws/.aws/config`: Stores AWS CLI configuration profiles, including default region, output format, and SSO settings. This allows for managing multiple AWS accounts and roles seamlessly.
+
+### Bat (`main/bat`)
+Bat is a `cat(1)` clone with syntax highlighting and Git integration. It provides a more user-friendly way to view file contents in the terminal.
+*   **Key Files:**
+    *   `main/bat/.config/bat/config`: Bat's configuration file, which can be used to customize themes, add new syntaxes, or integrate with other tools.
+
+### Docker (`main/docker`)
+Configuration for Docker, a platform for developing, shipping, and running applications in containers.
+*   **Key Files:**
+    *   `main/docker/.docker/config.json`: Stores Docker client configuration, such as authentication details for registries, default settings for builds, and plugin configurations.
+
+### GitHub CLI (`main/gh`)
+Configurations for `gh`, the official GitHub command-line interface. This allows for interacting with GitHub repositories, issues, pull requests, and more directly from the terminal.
+*   **Key Files:**
+    *   `main/gh/.config/gh/config.yml`: Stores authentication tokens, preferred editor, and other default settings for `gh`.
+    *   `main/gh/.config/gh/hosts.yml`: Manages authentication for different GitHub instances (e.g., github.com, GitHub Enterprise).
+
+### Git (`main/git`)
+Global Git configurations that define user identity, aliases, editor preferences, and other behaviors for version control.
+*   **Key Files:**
+    *   `main/git/.gitconfig`: The primary global Git configuration file. It includes user information (name, email), aliases for common commands, default editor, merge tool preferences, and more.
+    *   `main/git/.gitconfig.personal`: Likely a supplementary Git configuration file, possibly for personal project overrides or specific settings not included in the main `.gitconfig`. This might be included in the main `.gitconfig` via an `[include]` directive.
+
+### Neovim (`main/neovim`)
+Neovim is a highly extensible, Vim-based text editor. This configuration is extensive, tailored for a productive development environment.
+*   **For detailed Neovim setup, plugins, LSPs, and specific configurations, please see the [Neovim Configuration Documentation](./neovim.md).**
+*   **Key Directory:**
+    *   `main/neovim/.config/nvim/`: This directory contains all Neovim configuration files, including `init.lua` (or `init.vim`), plugin settings, LSP configurations, custom scripts, and themes.
+
+### SSH (`main/ssh`)
+Configurations for the Secure Shell (SSH) client, used for secure remote logins and file transfers.
+*   **Key Files:**
+    *   `main/ssh/.ssh/config`: Defines host-specific configurations, such as aliases for servers, usernames, identity files (private keys), port numbers, and other SSH options. This file is crucial for simplifying connections to frequently accessed remote machines.
+    *   `main/ssh/.ssh/aws-ssm-ec2-proxy-command.sh`: A script likely used in conjunction with the SSH config to connect to EC2 instances via AWS Systems Manager Session Manager, enhancing security by avoiding the need for open inbound SSH ports.
+    *   `main/ssh/.ssh/README.md`: Contains specific instructions or notes about the SSH setup, potentially covering key generation, agent forwarding, or usage of the proxy command. (Content from this README should be integrated here).
+
+### Terraform (`main/terraform`)
+Configuration for Terraform, an infrastructure as code (IaC) tool used to define and provision data center infrastructure using a declarative configuration language.
+*   **Key Files:**
+    *   `main/terraform/.tflint.hcl`: Configuration file for TFLint, a linter for Terraform code. It defines rules and settings to enforce best practices and catch errors in Terraform configurations.
+
+### Tmux (`main/tmux`)
+Tmux is a terminal multiplexer that allows users to manage multiple terminal sessions from a single window. It enables detaching and reattaching sessions, splitting windows into panes, and customizing status bars.
+*   **Key Files:**
+    *   `main/tmux/.config/tmux/tmux.conf`: The main configuration file for Tmux. It controls key bindings, appearance (status bar, colors), session behavior, and plugin management (e.g., via TPM - Tmux Plugin Manager).
+    *   The `plugins/` subdirectory likely contains plugins managed by TPM.
+
+### Zsh (`main/zsh`)
+Zsh (Z shell) is a powerful and highly customizable shell. This configuration enhances its functionality with plugins, themes, aliases, and custom functions.
+*   **Key Files:**
+    *   `main/zsh/.zshenv`: Read on startup for all Zsh invocations (interactive or not). Typically used to set environment variables like `$PATH`.
+    *   `main/zsh/.config/zsh/.zshrc`: The main configuration file for interactive Zsh sessions. It sources plugins, sets options, defines aliases and functions, and customizes the prompt.
+    *   `main/zsh/.config/zsh/aliases/`: Directory likely containing files with alias definitions, possibly organized by topic.
+    *   `main/zsh/.config/zsh/plugins/`: Could contain custom or manually installed plugins.
+    *   `main/zsh/.config/zsh/themes/`: Contains themes, including the `powerlevel10k` configuration (`p10k.zsh`).
+
+## Other (Work) Configurations
+
+These configurations are found in the `other/` directory and are specifically tailored for a work environment. They often override or supplement the main personal configurations.
+
+### GitHub CLI (`other/gh`)
+Work-specific configurations for the GitHub CLI (`gh`).
+*   **Purpose:** This configuration likely sets up `gh` to interact with a work-related GitHub Enterprise instance or a different GitHub user account used for professional projects.
+*   **Key Files:**
+    *   `other/gh/hosts.yml.other`: This file would contain the connection and authentication details for the work GitHub instance. The `.other` suffix suggests it's intended to be symlinked or copied to the appropriate location (e.g., `~/.config/gh/hosts.yml`) when the work environment is active.
+    *   `other/gh/.target`: This file likely specifies that `hosts.yml.other` should be symlinked as `hosts.yml` in the `~/.config/gh/` directory.
+
+### Git (`other/git`)
+Work-specific Git configurations.
+*   **Purpose:** To manage a separate Git identity (user name, email) for work contributions and potentially different Git settings or aliases relevant to the work environment.
+*   **Key Files:**
+    *   `other/git/.gitconfig.other`: Contains work-specific Git settings, such as work email and name. This file is typically included in the main global `.gitconfig` using Git's `includeIf` directive, activated based on the repository path (e.g., when in a `~/work/` directory).
+
+### SAML (`other/saml`)
+Configuration for SAML (Security Assertion Markup Language) based authentication, often used for Single Sign-On (SSO) to various services.
+*   **Purpose:** This likely configures tools like `saml2aws` which allow authentication to AWS or other cloud providers using corporate SAML SSO credentials.
+*   **Key Files:**
+    *   `other/saml/.saml2aws`: The configuration file for `saml2aws`. It stores profiles for different SSO providers and AWS roles, allowing users to log in and retrieve temporary AWS credentials.
+
+### Zsh (`other/zsh`)
+Work-specific Zsh configurations.
+*   **Purpose:** To add aliases, functions, or environment variables specific to the work environment, such_as connecting to work servers, managing work-specific projects, or using internal tools.
+*   **Key Files:**
+    *   `other/zsh/.config/utilities/`: This directory likely contains shell scripts or utility functions that are primarily used in a work context. These might be sourced by a work-specific Zsh configuration file. The specific files (`aws`, `git`, `kubectl`, `terraform`) suggest utilities for interacting with these tools, possibly with pre-configured settings or wrappers for work projects.
+
+---
+Properly managing these dotfiles ensures a tailored and efficient environment for both personal and professional tasks. Remember to use the `symlinks` script to install or update these configurations.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,11 @@
 # Welcome to Dotfiles Management Documentation
 
-This site provides a comprehensive guide to the collection of personal and work dotfiles, configurations for npm packages, Brew-installed tools, and the script for managing symlinks contained in this repository.
+This site provides a comprehensive guide to the collection of dotfiles, configurations for npm packages, Brew-installed tools, and the script for managing symlinks contained in this repository.
 
 ## Overview
 
 The repository is structured to manage different types of configurations:
-- **Dotfiles:** Personal (`main`) and work-related (`other`) configurations for various tools. [Read more about dotfiles](./dotfiles.md)
+- **Dotfiles:** Configurations for various tools. [Read more about dotfiles](./dotfiles.md)
 - **Symlink Management:** A script (`symlinks`) to create and manage symbolic links for these dotfiles. [Learn about the symlink script](./symlink-script.md)
 - **Homebrew Packages:** A `Brewfile` to manage macOS packages installed via Homebrew. [See Homebrew package details](./brew.md)
 - **NPM Packages:** A `package.json` for project-specific Node.js dependencies. [Explore NPM packages](./npm.md)
@@ -21,7 +21,7 @@ It allows for easy installation and uninstallation of configuration packages.
 
 This repository includes a variety of dotfiles for system customization and development. These are separated into personal (`main/`) and work-specific (`other/`) categories.
 
-### Main (Personal) Configurations
+### Configurations
 These are personal configurations located in the `main/` directory.
 
 *   `alacritty`: Configuration for Alacritty, a fast, cross-platform terminal emulator.
@@ -35,14 +35,6 @@ These are personal configurations located in the `main/` directory.
 *   `terraform`: Configuration for Terraform, an infrastructure as code tool.
 *   `tmux`: Configuration for tmux, a terminal multiplexer.
 *   `zsh`: Configuration for Zsh, a powerful shell with advanced features.
-
-### Other (Work) Configurations
-These are configurations tailored for a work environment, located in the `other/` directory.
-
-*   `gh`: Work-specific GitHub CLI configurations.
-*   `git`: Work-specific Git configurations.
-*   `saml`: Configuration for SAML authentication tools.
-*   `zsh`: Work-specific Zsh configurations.
 
 [Read more about dotfile configurations](./dotfiles.md)
 
@@ -65,5 +57,3 @@ The detailed Neovim setup, including plugin management, LSPs, and specific confi
 [View full Neovim Setup and Configuration](./neovim.md)
 
 ---
-*This documentation is actively maintained. For the most up-to-date information, please refer to the repository or visit the [live documentation site](https://YOUR_GITHUB_USERNAME.github.io/YOUR_REPOSITORY_NAME/).*
-Please replace `YOUR_GITHUB_USERNAME` and `YOUR_REPOSITORY_NAME` with your actual GitHub username and repository name.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,69 @@
+# Welcome to Dotfiles Management Documentation
+
+This site provides a comprehensive guide to the collection of personal and work dotfiles, configurations for npm packages, Brew-installed tools, and the script for managing symlinks contained in this repository.
+
+## Overview
+
+The repository is structured to manage different types of configurations:
+- **Dotfiles:** Personal (`main`) and work-related (`other`) configurations for various tools. [Read more about dotfiles](./dotfiles.md)
+- **Symlink Management:** A script (`symlinks`) to create and manage symbolic links for these dotfiles. [Learn about the symlink script](./symlink-script.md)
+- **Homebrew Packages:** A `Brewfile` to manage macOS packages installed via Homebrew. [See Homebrew package details](./brew.md)
+- **NPM Packages:** A `package.json` for project-specific Node.js dependencies. [Explore NPM packages](./npm.md)
+- **Themes:** Color schemes for terminal emulators.
+
+## `symlinks` Script
+
+The `symlinks` script manages all the dotfiles contained in this repo by means of the **stow** command.
+It allows for easy installation and uninstallation of configuration packages.
+[Learn more about the `symlinks` script and its usage](./symlink-script.md)
+
+## Dotfile Configurations
+
+This repository includes a variety of dotfiles for system customization and development. These are separated into personal (`main/`) and work-specific (`other/`) categories.
+
+### Main (Personal) Configurations
+These are personal configurations located in the `main/` directory.
+
+*   `alacritty`: Configuration for Alacritty, a fast, cross-platform terminal emulator.
+*   `aws`: Configuration for AWS CLI, providing credentials and default settings.
+*   `bat`: Configuration for Bat, a cat(1) clone with syntax highlighting and Git integration.
+*   `docker`: Configuration for Docker, a platform for developing, shipping, and running applications in containers.
+*   `gh`: Configuration for GitHub CLI, allowing command-line interaction with GitHub.
+*   `git`: Global Git configuration, including aliases and user settings.
+*   `neovim`: Extensive configuration for Neovim, a highly extensible text editor. [View full Neovim Setup and Configuration](./neovim.md)
+*   `ssh`: SSH client configuration, including host aliases and key settings.
+*   `terraform`: Configuration for Terraform, an infrastructure as code tool.
+*   `tmux`: Configuration for tmux, a terminal multiplexer.
+*   `zsh`: Configuration for Zsh, a powerful shell with advanced features.
+
+### Other (Work) Configurations
+These are configurations tailored for a work environment, located in the `other/` directory.
+
+*   `gh`: Work-specific GitHub CLI configurations.
+*   `git`: Work-specific Git configurations.
+*   `saml`: Configuration for SAML authentication tools.
+*   `zsh`: Work-specific Zsh configurations.
+
+[Read more about dotfile configurations](./dotfiles.md)
+
+## Homebrew Packages
+
+The `Brewfile` lists macOS packages installed via Homebrew. This allows for easy setup and replication of the development environment.
+[See Homebrew package details and management commands](./brew.md)
+
+## NPM Packages
+
+The `package.json` lists project-specific Node.js package dependencies, primarily for enhancing Neovim's capabilities.
+[Explore NPM packages used in this project](./npm.md)
+
+## Themes
+
+*   **iTerm2:** Rose Pine theme located at `theme/rosepine/iterm2/rosepine.itermcolors`.
+
+## Neovim Configuration Details
+The detailed Neovim setup, including plugin management, LSPs, and specific configurations, has been moved.
+[View full Neovim Setup and Configuration](./neovim.md)
+
+---
+*This documentation is actively maintained. For the most up-to-date information, please refer to the repository or visit the [live documentation site](https://YOUR_GITHUB_USERNAME.github.io/YOUR_REPOSITORY_NAME/).*
+Please replace `YOUR_GITHUB_USERNAME` and `YOUR_REPOSITORY_NAME` with your actual GitHub username and repository name.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # Welcome to Dotfiles Management Documentation
 
 This site provides a comprehensive guide to the collection of dotfiles, configurations for npm packages, Brew-installed tools, and the script for managing symlinks contained in this repository.

--- a/docs/neovim.md
+++ b/docs/neovim.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # Neovim Configuration Details
 
 This document provides a comprehensive overview of the Neovim setup, including build prerequisites, plugin dependencies, Language Server Protocol (LSP) configurations, and other specific settings used in this dotfiles repository.

--- a/docs/neovim.md
+++ b/docs/neovim.md
@@ -1,0 +1,141 @@
+# Neovim Configuration Details
+
+This document provides a comprehensive overview of the Neovim setup, including build prerequisites, plugin dependencies, Language Server Protocol (LSP) configurations, and other specific settings used in this dotfiles repository.
+
+The primary Neovim configuration is located in `main/neovim/.config/nvim/`.
+
+## Build Prerequisites
+
+To build Neovim from source or ensure all features work correctly, certain prerequisites might be needed. Refer to the official documentation for the most up-to-date list:
+*   [Neovim Build Prerequisites](https://github.com/neovim/neovim/wiki/Building-Neovim#build-prerequisites)
+
+## Initial Setup / Reset
+
+If you need to reset your Neovim environment (use with caution):
+```bash
+rm -rf ~/.environment/.neovim  # Or any custom directory for Neovim data/binaries
+rm -rf ~/.config/nvim
+rm -rf ~/.local/share/nvim
+```
+
+## Core Dependencies
+
+### Patched Fonts (for Icons)
+Many Neovim themes and plugins utilize icons for an enhanced user interface. It's crucial to install a patched Nerd Font and configure your terminal emulator to use it.
+*   **Resource:** [Nerd Fonts](https://github.com/ryanoasis/nerd-fonts)
+*   **Installation on macOS (example with Hack Nerd Font):**
+    ```bash
+    brew tap homebrew/cask-fonts
+    brew install --cask font-hack-nerd-font
+    ```
+    > **Warning:** Ensure your terminal emulator (e.g., Alacritty, iTerm2) is configured to use the installed Nerd Font. Otherwise, icons will not render correctly.
+
+## Plugin Management
+This configuration uses Packer or a similar plugin manager (details should be in `main/neovim/.config/nvim/init.lua` or a dedicated plugins file). Key plugins and their specific dependencies are listed below.
+
+### Plugin-Specific Dependencies & Notes:
+
+*   **`mason.nvim` (and `mason-lspconfig.nvim`)**:
+    *   Manages LSP servers, DAP servers, linters, and formatters.
+    *   Requires:
+        *   `wget`
+        *   `curl`
+        *   `cargo` and `rust` (for some components, install with: `curl https://sh.rustup.rs -sSf | sh`)
+
+*   **`nvim-cmp` (Auto-completion)**:
+    *   Provides completion features. Configuration details are critical for a good experience.
+    *   **Documentation:** [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
+
+*   **`telescope.nvim` (Fuzzy Finder)**:
+    *   A highly extendable fuzzy finder.
+    *   **Dependency:** `ripgrep` (for fast file searching). `brew install ripgrep`
+
+*   **`harpoon` (File/Mark Navigation)**:
+    *   Quickly navigate between frequently used files/buffers.
+    *   **Documentation:** [Harpoon](https://github.com/ThePrimeagen/harpoon)
+
+## Language Server Protocol (LSP) Configurations
+
+LSPs provide features like auto-completion, go-to-definition, diagnostics (linting/errors), and hover information. They are typically installed and managed via `mason.nvim`.
+
+### General LSP Dependencies:
+*   **C/C++ Compiler (for some LSPs or tree-sitter parsers):**
+    *   `sudo apt-get install build-essential` (Linux)
+    *   Xcode Command Line Tools (macOS)
+
+### Specific Language LSPs and Tools:
+
+*   **Bash:**
+    *   `bash-language-server`: Requires Node.js and npm.
+        *   Install Node.js: `sudo apt-get install nodejs` (or via `nvm`/`brew`)
+        *   Install server: `npm i -g bash-language-server`
+    *   `shellcheck` (for linting): `brew install shellcheck` or `sudo apt install shellcheck`
+
+*   **Python:**
+    *   Multiple LSP options exist (e.g., `pyright`, `python-lsp-server`). Check your Mason setup.
+    *   **Documentation (example for `python-lsp-server`):** [python-language-server](https://github.com/palantir/python-language-server) (Note: this specific server might be outdated; `pyright` is a common modern choice).
+    *   `pynvim` (for Python plugin support in Neovim): `pip3 install pynvim`
+    *   **Linters/Formatters:**
+        *   `flake8` (diagnostics): `pip install flake8`
+        *   `autopep8` (formatting): `pip install autopep8` (or `black`, `isort`)
+
+*   **Java:**
+    *   `jdtls` (Eclipse JDT Language Server). Managed by Mason.
+    *   **References & Dependencies:**
+        *   [nvim-jdtls (Neovim plugin)](https://github.com/mfussenegger/nvim-jdtls)
+        *   [eclipse.jdt.ls (The language server itself)](https://github.com/eclipse/eclipse.jdt.ls#installation)
+        *   [nvim-dap (Debug Adapter Protocol plugin)](https://github.com/mfussenegger/nvim-dap)
+        *   [vscode-java-test (for running tests)](https://github.com/microsoft/vscode-java-test)
+    *   **System Dependencies:**
+        *   `maven` or `gradle` (project build tools): `sudo apt-get install -y maven`
+        *   JDK (e.g., OpenJDK 8 or later): `sudo apt-get install -y openjdk-8-jdk`
+
+*   **Hurl (HTTP Testing):**
+    *   For testing HTTP requests easily.
+    *   **Website:** [hurl.dev](https://hurl.dev/)
+    *   An LSP for Hurl might be available via Mason.
+
+*   **Go (`gopls`):**
+    *   The official Go language server.
+    *   **Installation (if not using Mason):** `go install golang.org/x/tools/gopls@latest`
+
+*   **HTML/CSS/JavaScript:**
+    *   **Emmet:** For faster HTML/CSS development.
+        *   Plugin: `emmet-vim` ([mattn/emmet-vim](https://github.com/mattn/emmet-vim))
+        *   **Tutorial:** [Emmet Tutorial](https://raw.githubusercontent.com/mattn/emmet-vim/master/TUTORIAL)
+    *   LSPs like `vscode-langservers-extracted` (for HTML, CSS, JSON, ESLint) or `tailwindcss-language-server` are typically used.
+
+*   **Terraform:**
+    *   `terraform-ls` (HashiCorp Language Server for Terraform).
+    *   **Installation (if not using Mason):** `brew install hashicorp/tap/terraform-ls`
+    *   **Documentation:** [terraform-ls](https://github.com/hashicorp/terraform-ls)
+    *   **Packer (for building Packer templates, often used with Terraform):**
+        *   `brew tap hashicorp/tap && brew install hashicorp/tap/packer`
+
+*   **HTMX:**
+    *   Language server for HTMX.
+    *   **Installation (if not using Mason):** `cargo install htmx-lsp`
+    *   **Neovim LSP Config Documentation:** [htmx](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#htmx)
+
+*   **Tailwind CSS:**
+    *   `tailwindcss-language-server` for Tailwind CSS autocompletion and linting.
+    *   **Installation (if not using Mason):** `npm install -g @tailwindcss/language-server`
+    *   **Documentation:**
+        *   [Tailwind CSS IntelliSense](https://github.com/tailwindlabs/tailwindcss-intellisense/tree/master/packages/tailwindcss-language-server)
+        *   [Neovim LSP Config: tailwindcss](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#tailwindcss)
+
+*   **Angular:**
+    *   `@angular/language-server` for Angular template support.
+    *   **Installation (if not using Mason):** `npm install -g @angular/language-server`
+    *   **Angular CLI (optional but recommended for Angular development):** `npm install -g @angular/cli`
+    *   **Neovim LSP Config Documentation:** [angularls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#angularls)
+
+## GitHub Copilot
+
+If using GitHub Copilot:
+*   **Plugin:** `copilot.vim` or a Lua equivalent.
+*   **Documentation:** [copilot.vim](https://github.com/github/copilot.vim?tab=readme-ov-file)
+    *   Follow setup instructions, including authentication.
+
+---
+This document outlines the core components of the Neovim configuration. For the actual Lua configuration files, plugin lists, and key mappings, please refer to the files within the `main/neovim/.config/nvim/` directory.

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -1,0 +1,39 @@
+# NPM Packages Documentation
+
+This document outlines the Node.js packages managed via the `package.json` file in this repository. These packages are primarily installed to enhance the capabilities of Neovim, particularly for Language Server Protocol (LSP) support and other development utilities.
+
+## `package.json`
+
+The `package.json` file is located at the root of the repository and lists project-specific Node.js dependencies.
+
+### Managing NPM Packages:
+
+While these packages are listed in `package.json`, they are typically installed globally or managed by Neovim's plugin manager (like Mason) which might handle their installation into a Neovim-specific directory. If you need to install them manually for system-wide use or for Neovim to find them (if not managed by a plugin manager):
+
+*   **Install all dependencies locally (in `node_modules`):**
+    ```bash
+    npm install
+    ```
+*   **Install a package globally (example):**
+    ```bash
+    npm install -g @angular/language-server
+    ```
+
+Consult your Neovim plugin manager's documentation (e.g., Mason) to see how it handles these NPM-based language servers. Often, no manual NPM installation is needed if Mason is configured correctly.
+
+## Dependencies
+
+The following packages are listed as dependencies in `package.json`:
+
+### `@angular/language-server`
+*   **Version:** `^17.3.1` (as per the `package.json` provided)
+*   **Purpose:** This package provides language server capabilities for Angular projects. It enables features like autocompletion, error checking, and navigation within Angular templates (`.html` files) and TypeScript code related to Angular components.
+*   **Use in Project:** Primarily used by Neovim's LSP client (via `lspconfig` and Mason) to offer rich editing features for Angular development.
+
+### `@anthropic-ai/claude-code`
+*   **Version:** `^0.2.117` (as per the `package.json` provided)
+*   **Purpose:** This package is likely related to providing AI-assisted coding features using Anthropic's Claude models. It might be a client library or a tool that integrates with Neovim to offer code suggestions, explanations, or generation.
+*   **Use in Project:** Integrated into the Neovim setup to leverage AI for coding tasks, potentially through a specific Neovim plugin designed to work with Claude or a general-purpose AI plugin that supports it.
+
+---
+These NPM packages extend the development environment, particularly within Neovim, by adding advanced language support and potentially AI-driven coding assistance. Refer to the Neovim configuration for details on how these packages are integrated.

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # NPM Packages Documentation
 
 This document outlines the Node.js packages managed via the `package.json` file in this repository. These packages are primarily installed to enhance the capabilities of Neovim, particularly for Language Server Protocol (LSP) support and other development utilities.

--- a/docs/symlink-script.md
+++ b/docs/symlink-script.md
@@ -1,3 +1,7 @@
+---
+layout: default
+---
+
 # `symlinks` Script Documentation
 
 The `symlinks` script is a utility designed to manage dotfiles within this repository using the **stow** command. It simplifies the process of creating and removing symbolic links for various configuration "packages."

--- a/docs/symlink-script.md
+++ b/docs/symlink-script.md
@@ -1,0 +1,98 @@
+# `symlinks` Script Documentation
+
+The `symlinks` script is a utility designed to manage dotfiles within this repository using the **stow** command. It simplifies the process of creating and removing symbolic links for various configuration "packages."
+
+## Core Functionality
+
+A **package** is defined as a collection of files and directories that you wish to administer as a unit. These packages are intended to be installed into a specific directory structure, starting from a designated **target folder**.
+
+When a package is "installed" using the script, its contents will appear to be located in the **target directory** (the root tree where symlinks are created), while the actual files remain within this repository. This allows for version control and easy management of configurations across different environments or machines.
+
+## Features
+
+*   **Selective Symlinking:** Create or remove symlinks for specified packages.
+*   **Custom Target Directory:** Define a target directory for symlinks, defaulting to `$HOME`.
+*   **Recursive Operation:** Option to iterate through subdirectories within a package and stow all their contents.
+*   **Ignoring Files:** Specify files or directories to be ignored during the symlinking process using the `--ignore` option.
+*   **Custom Target Paths:** Define a `.target` file within a package directory. This file can contain a path to a specific target file, overriding the default behavior of mirroring the current folder structure.
+
+## Usage
+
+The script is invoked from the command line with various options:
+
+```bash
+./symlinks [--install | -i] [--uninstall | -u] [--recursive | -r] [--target | -t] <TARGET_VALUE> FOLDER
+```
+
+### Command Options:
+
+*   `--install` or `-i`:
+    *   **Action:** Creates symbolic links for the specified `FOLDER` (package) into the `TARGET_VALUE` directory.
+*   `--uninstall` or `-u`:
+    *   **Action:** Removes previously created symbolic links for the specified `FOLDER` from the `TARGET_VALUE` directory.
+*   `--target` or `-t` `<TARGET_VALUE>`:
+    *   **Action:** Specifies the target directory where symlinks will be created or removed.
+    *   **Default:** `$HOME` (your home directory).
+*   `--recursive` or `-r`:
+    *   **Action:** When used with `--install` or `--uninstall`, this option will iterate through all directories inside the specified `FOLDER` (stow package) and apply the stow operation to all their content. This is useful for packages that have a nested structure.
+*   `--help` or `-h`:
+    *   **Action:** Displays a help menu with usage instructions and option explanations.
+*   `FOLDER`:
+    *   **Required Argument:** Specifies the source folder (package) within the repository that you want to install or uninstall. For example, `main/zsh` or `other/git`.
+
+## Examples
+
+1.  **Install a Personal Zsh Configuration:**
+    To create symlinks for your personal Zsh configuration files located in `main/zsh` to your home directory:
+    ```bash
+    ./symlinks --install main/zsh
+    ```
+    or using the short-hand:
+    ```bash
+    ./symlinks -i main/zsh
+    ```
+
+2.  **Uninstall a Work-Specific Git Configuration:**
+    To remove symlinks for a work-specific Git configuration located in `other/git` from your home directory:
+    ```bash
+    ./symlinks --uninstall other/git
+    ```
+    or:
+    ```bash
+    ./symlinks -u other/git
+    ```
+
+3.  **Install a Package to a Custom Target Directory:**
+    To install a work-specific tool configuration (e.g., `other/specific_tool`) into a custom target directory like `~/.config/other_configs`:
+    ```bash
+    ./symlinks --install --target ~/.config/other_configs other/specific_tool
+    ```
+    or:
+    ```bash
+    ./symlinks -i -t ~/.config/other_configs other/specific_tool
+    ```
+
+4.  **Recursively Install a Package with Nested Directories:**
+    If you have a package, for instance `main/complex_tool`, which contains multiple subdirectories that themselves need to be stowed into the target directory, you would use:
+    ```bash
+    ./symlinks -i -r main/complex_tool
+    ```
+    This will stow `main/complex_tool/sub_config1`, `main/complex_tool/sub_config2`, etc., into the target directory.
+
+5.  **Ignoring Specific Files During Installation:**
+    If a package `main/my_app` contains a `temp_notes.txt` file that you don't want to symlink, you could run:
+    ```bash
+    ./symlinks -i --ignore temp_notes.txt main/my_app
+    ```
+    Multiple files/directories can be ignored by repeating the `--ignore` option or by providing a comma-separated list (check script's specific implementation for multiple ignores).
+
+## `.target` File for Custom Paths
+
+In some cases, a file within your package directory needs to be symlinked to a location that doesn't directly mirror the structure of your dotfiles repository. For example, you might have `main/my_editor/config.json` but it needs to be symlinked to `~/.config/my_editor_app/settings.json`.
+
+To handle this, you can create a `.target` file inside the `main/my_editor` directory. The content of this `.target` file would be the desired absolute path for `config.json`, or a path relative to the main target directory. The `symlinks` script would then read this file to determine the correct symlink location for `config.json`.
+
+**Note:** The exact implementation details of how the `.target` file is parsed and used should be verified within the `symlinks` script itself.
+
+---
+This script is crucial for maintaining a clean and organized set of dotfiles, allowing for easy management and deployment across different systems.


### PR DESCRIPTION
This commit introduces a comprehensive update to the project documentation.

- The main README.md has been restructured to provide a concise overview of the repository, including dotfiles, Brewfile packages, npm packages, and the symlink script. It now directs you to a new, more detailed documentation site.

- A `docs/` directory has been created to house the detailed documentation, intended for publication via GitHub Pages. This includes:
    - `docs/index.md`: The main landing page for the documentation site.
    - `docs/symlink-script.md`: Detailed usage and explanation of the `symlinks` script.
    - `docs/dotfiles.md`: In-depth descriptions of each configuration in the `main/` and `other/` directories.
    - `docs/neovim.md`: Comprehensive setup guide for Neovim, including prerequisites, plugins, and LSPs.
    - `docs/brew.md`: A full list of packages from the `Brewfile`, categorized and described.
    - `docs/npm.md`: Details on npm packages from `package.json`.
    - `docs/.nojekyll`: Ensures proper serving of the static site on GitHub Pages.

- Placeholder links for the GitHub Pages site have been added to `README.md` and `docs/index.md`, which you will need to update with your specific GitHub username and repository name.